### PR TITLE
chore: fix type errors and lint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,10 @@ module.exports = {
 		'prettier/prettier': 'error',
 		'no-use-before-define': 'off'
 	},
-	env: { es2017: true },
+	env: {
+		es2017: true,
+		node: true
+	},
 	parserOptions: { sourceType: 'module', ecmaVersion: 2018 },
 	overrides: [
 		{
@@ -24,11 +27,12 @@ module.exports = {
 			],
 			rules: {
 				'no-use-before-define': 'off',
-				'@typescript-eslint/no-use-before-define': 'off'
+				'@typescript-eslint/no-use-before-define': 'off',
+				'@typescript-eslint/explicit-function-return-type': 'off'
 			}
 		},
 		{
-			files: ['src/**/__tests__/*.test.ts'],
+			files: ['src/**/__tests__/*.spec.ts'],
 			parserOptions: { project: './tsconfig.jest.json' },
 			env: {
 				jest: true

--- a/jest-integration.config.js
+++ b/jest-integration.config.js
@@ -1,4 +1,3 @@
-/*global module */
 module.exports = {
 	globals: {
 		'ts-jest': {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
-/*global module */
 module.exports = {
 	moduleFileExtensions: ['ts', 'js'],
 	transform: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,8 +8,7 @@ import {
 	CommandNames,
 	ErrorCode,
 	NotifyType,
-	ResponseInterface,
-	Response
+	ResponseInterface
 } from './types'
 import { createServer, Server } from 'net'
 
@@ -82,11 +81,13 @@ export class HyperdeckServer {
 	}
 
 	private async _receivedCommand(cmd: DeserializedCommand): Promise<TResponse> {
-		const intErrorCatch = (err?: { code: number; msg: string }) => {
+		const intErrorCatch = (err?: { code: number; msg: string }): TResponse => {
 			if (err) return new TResponse(err.code, err.msg)
 			else return new TResponse(ErrorCode.InternalError, 'internal error')
 		}
-		let executor: ((command: DeserializedCommand) => Promise<Response | void>) | undefined
+		let executor:
+			| ((command: DeserializedCommand) => Promise<typeof ResponseInterface | void>)
+			| undefined
 		let resHandler: ((res?: Hash<string>) => TResponse) | undefined
 
 		if (cmd.name === CommandNames.DeviceInfoCommand) {

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -77,14 +77,18 @@ export class HyperdeckSocket extends EventEmitter {
 				const notifyCmd = cmd as DeserializedCommands.NotifyCommand
 
 				if (Object.keys(notifyCmd.parameters).length > 0) {
-					for (const param of Object.keys(notifyCmd.parameters)) {
+					for (const param of Object.keys(notifyCmd.parameters) as Array<
+						keyof typeof notifyCmd.parameters
+					>) {
 						if (this._notifySettings[param] !== undefined) {
 							this._notifySettings[param] = notifyCmd.parameters[param] === 'true'
 						}
 					}
 				} else {
 					const settings: Hash<string> = {}
-					for (const key in Object.keys(this._notifySettings)) {
+					for (const key of Object.keys(this._notifySettings) as Array<
+						keyof HyperdeckSocket['_notifySettings']
+					>) {
 						settings[key] = this._notifySettings[key] ? 'true' : 'false'
 					}
 					this.sendResponse(new TResponse(SynchronousCode.Notify, 'notify', settings))


### PR DESCRIPTION
This PR fixes TypeScript build errors and ESLint lint errors. `yarn lint` and `yarn tsc --noEmit` now both pass without issue.