### PR TITLE
Update the Version of the Protocol to 1.8 so that the Atem works with…

### DIFF
--- a/src/socket.ts
+++ b/src/socket.ts
@@ -44,7 +44,7 @@ export class HyperdeckSocket extends EventEmitter {
 
 		this.sendResponse(
 			new TResponse(AsynchronousCode.ConnectionInfo, 'connection info', {
-				'protocol version': '1.6',
+				'protocol version': '1.8',
 				model: 'NodeJS Hyperdeck Server Library'
 			})
 		)


### PR DESCRIPTION
Updating the Version displayed in the Libary to 1.8 
The minimum required version on all ATEMs has been upgraded to 1.8
HyperDeck protocol version 1.8 added the capability to request multiple clips at once using `clips get: id: [n] count: [m] ` command.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix 
* **What is the current behavior?** (You can also link to an open issue here)
Atem tells the user to upgrade the Software 
- **What is the new behavior (if this is a feature change)?**
Atem will work with the library again
* **Other information**:
